### PR TITLE
Force reply queue names to be random always

### DIFF
--- a/lib/client-hook.js
+++ b/lib/client-hook.js
@@ -46,7 +46,6 @@ var ClientHook = (function() {
       resQueue: ['channel', function(cb, results) {
         var channel = results.channel;
         var qres = options.queues.response;
-        qres.id = options.id;
         var queueName = Amqputil.resolveClientQueue(qres);
         return channel.assertQueue(queueName, qres.options, function(err, ok) {
           return cb(err, ok.queue);


### PR DESCRIPTION
Remove option to define reply queue name as it was clashing with internal Seneca arguments.